### PR TITLE
Add some error handling around loading user

### DIFF
--- a/controllers/courses.js
+++ b/controllers/courses.js
@@ -2,9 +2,9 @@ const Courses = require('../models/courses');
 
 // Get courses
 const getCourses = async (req, res) => {
-    //    if (!req.user) {
-    //         return res.status(401).send({ message: 'Not Authenticated' })
-    //     } 
+       if (!req.user) {
+            return res.status(401).send({ message: 'Not Authenticated' })
+        } 
     try {
         const courses = await Courses.find();
         res.status(200).json(courses);

--- a/middleware/loadUser.js
+++ b/middleware/loadUser.js
@@ -2,12 +2,16 @@ const appConfig = require('../config/app')
 const User = require('../models/courseUsers');
 
 const loadUser = async (req, res, next) => {
-    const authZeroUser = await fetchAuthZeroUser(req.headers.authorization);
+    try {
+        const authZeroUser = await fetchAuthZeroUser(req.headers.authorization);
     // console.log(authZeroUser);
     const user = await findOrCreateUser(authZeroUser);
     // console.log(user);
     req.user = user;
     next();
+    } catch(_error) {
+        next()
+    }
 }
 
 const fetchAuthZeroUser = async (authorizationValue) => {


### PR DESCRIPTION
I would recommend adding this small bit of error handling to loadUser middleware to prevent crashes when an access token is not present, expired, or invalid.